### PR TITLE
feat: create service account for GKE worker nodes

### DIFF
--- a/terraform/cluster.tf
+++ b/terraform/cluster.tf
@@ -25,6 +25,13 @@ resource "google_container_cluster" "cluster" {
     update = "30m"
     delete = "30m"
   }
+
+  node_config {
+    service_account = module.google_service_account.email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+  }
 }
 
 
@@ -59,6 +66,7 @@ resource "google_container_node_pool" "master" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
+    service_account = module.google_service_account.email
     oauth_scopes    = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -13,6 +13,11 @@ output "project_id" {
   description = "GCloud Project ID"
 }
 
+output "worker_service_account" {
+  value       = module.google_service_account.email
+  description = "Service Account used by GKE workers to run ingest"
+}
+
 output "kubernetes_cluster_name" {
   value       = google_container_cluster.cluster.name
   description = "GKE Cluster Name"

--- a/terraform/pools.tf
+++ b/terraform/pools.tf
@@ -51,6 +51,7 @@ resource "google_container_node_pool" "pool" {
     metadata     = {
       disable-legacy-endpoints = "true"
     }
+    service_account = module.google_service_account.email
     oauth_scopes    = [
       "https://www.googleapis.com/auth/cloud-platform"
     ]

--- a/terraform/serviceaccount.tf
+++ b/terraform/serviceaccount.tf
@@ -1,0 +1,12 @@
+module "google_service_account" {
+  source        = "terraform-google-modules/service-accounts/google"
+  version       = "~> 4.1.1"
+  project_id    = "${var.project_id}"
+  prefix        = "${var.common_name}"
+  names         = ["worker-svc"]
+  project_roles = [
+    "${var.project_id}=>roles/bigtable.admin",                   # Generate table within Bigtable instance
+    "${var.project_id}=>roles/storage.objectAdmin",              # Generate/overwrite components/edge bucket objects
+    "${var.project_id}=>roles/containerregistry.ServiceAgent",   # Access PCG images on GCR
+  ]
+}


### PR DESCRIPTION
Creates a more restricted service account for the worker nodes, rather than the default GCP account.